### PR TITLE
Change Idenitity tables having `text` fields

### DIFF
--- a/Rinkudesu.Identity.Service/Data/IdentityContext.cs
+++ b/Rinkudesu.Identity.Service/Data/IdentityContext.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable CS1591
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Rinkudesu.Identity.Service.Models;
@@ -10,5 +11,29 @@ public class IdentityContext : IdentityDbContext<User, Role, Guid>
     public IdentityContext(DbContextOptions<IdentityContext> options) : base(options)
     {
     }
-    //todo: some of the identity storage columns should have types changed from text to something actually reasonable
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+
+        #region database type changes for tables without explicit classes
+        // In the perfect world all of those classes should be inherited and have those limits specified explicitly,
+        // but that's too much work for only applying database types, so I'll do it this way.
+
+        builder.Entity<IdentityRoleClaim<Guid>>().Property(t => t.ClaimType).HasMaxLength(500);
+        builder.Entity<IdentityRoleClaim<Guid>>().Property(t => t.ClaimValue).HasMaxLength(500);
+
+        builder.Entity<IdentityUserClaim<Guid>>().Property(t => t.ClaimType).HasMaxLength(500);
+        builder.Entity<IdentityUserClaim<Guid>>().Property(t => t.ClaimValue).HasMaxLength(500);
+
+        builder.Entity<IdentityUserLogin<Guid>>().Property(t => t.LoginProvider).HasMaxLength(500);
+        builder.Entity<IdentityUserLogin<Guid>>().Property(t => t.ProviderKey).HasMaxLength(500);
+        builder.Entity<IdentityUserLogin<Guid>>().Property(t => t.ProviderDisplayName).HasMaxLength(500);
+
+        builder.Entity<IdentityUserToken<Guid>>().Property(t => t.LoginProvider).HasMaxLength(500);
+        builder.Entity<IdentityUserToken<Guid>>().Property(t => t.Name).HasMaxLength(500);
+        builder.Entity<IdentityUserToken<Guid>>().Property(t => t.Value).HasMaxLength(1000);
+
+        #endregion
+    }
 }

--- a/Rinkudesu.Identity.Service/Data/IdentityContext.cs
+++ b/Rinkudesu.Identity.Service/Data/IdentityContext.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable CS1591
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
@@ -6,6 +7,7 @@ using Rinkudesu.Identity.Service.Models;
 
 namespace Rinkudesu.Identity.Service.Data;
 
+[ExcludeFromCodeCoverage]
 public class IdentityContext : IdentityDbContext<User, Role, Guid>
 {
     public IdentityContext(DbContextOptions<IdentityContext> options) : base(options)

--- a/Rinkudesu.Identity.Service/Migrations/20230506132457_IdentityLengthLimits.Designer.cs
+++ b/Rinkudesu.Identity.Service/Migrations/20230506132457_IdentityLengthLimits.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Rinkudesu.Identity.Service.Data;
@@ -11,9 +12,11 @@ using Rinkudesu.Identity.Service.Data;
 namespace Rinkudesu.Identity.Service.Migrations
 {
     [DbContext(typeof(IdentityContext))]
-    partial class IdentityContextModelSnapshot : ModelSnapshot
+    [Migration("20230506132457_IdentityLengthLimits")]
+    partial class IdentityLengthLimits
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Rinkudesu.Identity.Service/Migrations/20230506132457_IdentityLengthLimits.cs
+++ b/Rinkudesu.Identity.Service/Migrations/20230506132457_IdentityLengthLimits.cs
@@ -1,0 +1,310 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Rinkudesu.Identity.Service.Migrations
+{
+    /// <inheritdoc />
+    public partial class IdentityLengthLimits : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Value",
+                table: "AspNetUserTokens",
+                type: "character varying(1000)",
+                maxLength: 1000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "AspNetUserTokens",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LoginProvider",
+                table: "AspNetUserTokens",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SecurityStamp",
+                table: "AspNetUsers",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "PhoneNumber",
+                table: "AspNetUsers",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "PasswordHash",
+                table: "AspNetUsers",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "AspNetUsers",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ProviderDisplayName",
+                table: "AspNetUserLogins",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ProviderKey",
+                table: "AspNetUserLogins",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LoginProvider",
+                table: "AspNetUserLogins",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ClaimValue",
+                table: "AspNetUserClaims",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ClaimType",
+                table: "AspNetUserClaims",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "AspNetRoles",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ClaimValue",
+                table: "AspNetRoleClaims",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ClaimType",
+                table: "AspNetRoleClaims",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Value",
+                table: "AspNetUserTokens",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(1000)",
+                oldMaxLength: 1000,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "AspNetUserTokens",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LoginProvider",
+                table: "AspNetUserTokens",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SecurityStamp",
+                table: "AspNetUsers",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "PhoneNumber",
+                table: "AspNetUsers",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "PasswordHash",
+                table: "AspNetUsers",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "AspNetUsers",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ProviderDisplayName",
+                table: "AspNetUserLogins",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ProviderKey",
+                table: "AspNetUserLogins",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LoginProvider",
+                table: "AspNetUserLogins",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ClaimValue",
+                table: "AspNetUserClaims",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ClaimType",
+                table: "AspNetUserClaims",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "AspNetRoles",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ClaimValue",
+                table: "AspNetRoleClaims",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ClaimType",
+                table: "AspNetRoleClaims",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+        }
+    }
+}

--- a/Rinkudesu.Identity.Service/Models/InputArguments.cs
+++ b/Rinkudesu.Identity.Service/Models/InputArguments.cs
@@ -16,10 +16,9 @@ public class InputArguments
 
 #if DEBUG
     // not sure what that is but is apparently set during migration creation, so to avoid issues let's just set it here
-    [Option(longName: "applicationName", Required = false)]
-    public string ApplicationName { get; set; }
-    [Option(longName: "newMigration", Required = false)]
-    public bool NewMigrationCreation { get; set; }
+    [Option(longName: "applicationName", Required = false, HelpText = "DON'T USE: this is an argument that's inexplicably passed by ef when creating a new migration. When set, the application will treat it as a sign that a new migration is being created and will not start.")]
+    public string ApplicationName { get; set; } = string.Empty;
+    public bool NewMigrationCreation => !string.IsNullOrWhiteSpace(ApplicationName);
 #endif
 
     public void SaveAsCurrent()

--- a/Rinkudesu.Identity.Service/Models/Role.cs
+++ b/Rinkudesu.Identity.Service/Models/Role.cs
@@ -1,8 +1,11 @@
-﻿using Microsoft.AspNetCore.Identity;
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Identity;
 
 namespace Rinkudesu.Identity.Service.Models;
 
 /// <inheritdoc/>
 public class Role : IdentityRole<Guid>
 {
+    [MaxLength(256)]
+    public override string? ConcurrencyStamp { get; set; }
 }

--- a/Rinkudesu.Identity.Service/Models/User.cs
+++ b/Rinkudesu.Identity.Service/Models/User.cs
@@ -1,8 +1,21 @@
-﻿using Microsoft.AspNetCore.Identity;
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Identity;
 
 namespace Rinkudesu.Identity.Service.Models;
 
 /// <inheritdoc/>
 public class User : IdentityUser<Guid>
 {
+    #region database type changes from text to varchar
+
+    [MaxLength(500), DataType(DataType.Password)]
+    public override string? PasswordHash { get; set; }
+    [MaxLength(500)]
+    public override string? SecurityStamp { get; set; }
+    [MaxLength(256)]
+    public override string? ConcurrencyStamp { get; set; }
+    [MaxLength(100), DataType(DataType.PhoneNumber)]
+    public override string? PhoneNumber { get; set; }
+
+    #endregion
 }


### PR DESCRIPTION
Some default identity columns in the database had `text` type, which is generally not good.
